### PR TITLE
Code Review: Make Zipped JSON our official File Format (#8880)

### DIFF
--- a/unzip.c
+++ b/unzip.c
@@ -946,10 +946,10 @@ local int unz64local_GetCurrentFileInfoInternal(unzFile file, unz_file_info64 *p
         if ((file_info.size_file_comment > 0) && (comment_size > 0))
             if (ZREAD64(s->z_filefunc, s->filestream_with_CD, comment, (uLong)bytes_to_read) != bytes_to_read)
                 err = UNZ_ERRNO;
-        lSeek += file_info.size_file_comment - (uLong)bytes_to_read;
+//        lSeek += file_info.size_file_comment - (uLong)bytes_to_read;
     }
-    else
-        lSeek += file_info.size_file_comment;
+//    else
+//        lSeek += file_info.size_file_comment;
 
     if ((err == UNZ_OK) && (pfile_info != NULL))
         *pfile_info = file_info;
@@ -1293,7 +1293,7 @@ extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method, int* level, in
     }
 #endif
 
-    return UNZ_OK;
+    return err;
 }
 
 extern int ZEXPORT unzOpenCurrentFile(unzFile file)

--- a/zip.c
+++ b/zip.c
@@ -1133,7 +1133,10 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
     zi->ci.pos_zip64extrainfo = 0;
 
     /* Write the local header */
-    err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)LOCALHEADERMAGIC, 4);
+    if (err == ZIP_OK)
+    {
+      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)LOCALHEADERMAGIC, 4);
+    }
 
     if (err == ZIP_OK)
     {
@@ -1204,10 +1207,16 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
         zi->ci.pos_zip64extrainfo = ZTELL64(zi->z_filefunc, zi->filestream);
 
         err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)headerid, 2);
-        err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)datasize, 2);
+        if (Z_OK == err) {
+          err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)datasize, 2);
+        }
 
-        err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)uncompressed_size, 8);
-        err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)compressed_size, 8);
+        if (Z_OK == err) {
+          err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)uncompressed_size, 8);
+        }
+        if (Z_OK == err) {
+          err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)compressed_size, 8);
+        }
     }
 #ifdef HAVE_AES
     /* Write the AES extended info */
@@ -1610,9 +1619,11 @@ extern int ZEXPORT zipCloseFileInZipRaw64(zipFile file, ZPOS64_T uncompressed_si
                     zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
                     zi->ci.stream.next_out = zi->ci.buffered_data;
                 }
-                total_out_before = zi->ci.stream.total_out;
-                err = deflate(&zi->ci.stream, Z_FINISH);
-                zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - total_out_before);
+                if (ZIP_OK == err) {
+                  total_out_before = zi->ci.stream.total_out;
+                  err = deflate(&zi->ci.stream, Z_FINISH);
+                  zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - total_out_before);
+                }
             }
         }
         else if (zi->ci.compression_method == Z_BZIP2ED)
@@ -1748,7 +1759,7 @@ extern int ZEXPORT zipCloseFileInZipRaw64(zipFile file, ZPOS64_T uncompressed_si
         if (zi->ci.pos_local_header >= 0xffffffff)
         {
             zip64local_putValue_inmemory(p, zi->ci.pos_local_header, 8);
-            p += 8;
+//            p += 8;
         }
 
         zi->ci.size_centralextrafree -= datasize + 4;


### PR DESCRIPTION
Code review for Make Zipped JSON our official File Format (#8880):

> In #8756 we wrote a proof-of-concept to test the various approaches. Zipped JSON was surprisingly small compared to what we have now, and it didn't increase in size that much. The benefit of being able to do/allow server-side file parsing makes this the preferred option. Let's build it! :-D
> 
> This'll be for @opsGavin since he built the POC, but also pinging in @samdeane and @mikeabdullah since I know he shares a keen interest in all things zip.
> 
> For now I think it makes sense to only use the Intermediate Value Tree (#9190) for unarchiving since we win nothing by using it for archiving too. Yet we'll make a pluggable NSCoding-like class so we can easily do it later if needed
> ## 
> 
> Things to look out for:
> 1. We use `ZipKit` already so we should either use that or make sure we update existing code to deal with `minizip' (which the POC used). Either way, we should have 1 zip package
> 2. Make sure QuickLook keeps working with new and old files
> 3. Even though our file format might for the moment only be 1 json file, it's expected that we'll have other files in there at some point so if we start with a zipped directory from the start that might make sense
> ## 
> 
> Possible steps to take:
> - [x] Replace our MSArchiver with a custom serialiser class so we can plug in a JSON serialiser later #9365
> - [x] Replace our MSUnarchiver with a custom deserialiser so we can plug in a JSON deserialiser later #9402
> - [x] Write the above serialiser #9401
> - [x] Write a deserialiser than reads in a mutable value tree, can perform migrations on that and then pass that to the immutables in a custom MSUnarchiver-type subclass #9403
> - [x] Wrap the new JSON in a zipped folder with images and a `metadata.json` and make Sketch archive and unarchive that besides keeping support for unarchiving the old SQL format
> - [x] Adapt the QL plugin to check for this image and fall back to an SQL read for the old format
> - [ ] Make sure we can do migrations and detect documents that are too new like we can now
> - [ ] Make sure missing fonts etc are recognises like they used to be
> - [x] Embed a preview of the first page in the Zip for QL and other tools
> - [ ] Make sure old versions of Sketch don't crash but display some kind of sensible error with encountering the new file
> - [ ] Make sure we can do some test migrations easily


Connect to BohemianCoding/Sketch#8880.